### PR TITLE
SKETCH-2533: Add descriptive tooltips for atoms, bonds, and s-groups

### DIFF
--- a/src/schrodinger/sketcher/molviewer/atom_item.h
+++ b/src/schrodinger/sketcher/molviewer/atom_item.h
@@ -234,6 +234,15 @@ class SKETCHER_API AtomItem : public AbstractAtomOrMonomerItem
     void updateMappingLabel();
 
     /**
+     * Get tooltip text based on atom labels (chirality or query).
+     * Returns tooltip text for labels related to stereochemistry or query features.
+     * If an atom has both stereochemistry and query features, both are shown on
+     * separate lines (e.g., "Stereo: (R)\nQuery: X2").
+     * @return tooltip text, or empty string if no tooltip should be shown
+     */
+    QString getTooltip() const;
+
+    /**
      * create a label for the charge and radical information  (if present)
      */
     void updateChargeAndRadicalLabel();

--- a/src/schrodinger/sketcher/molviewer/bond_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/bond_item.cpp
@@ -28,6 +28,7 @@
 #include <QMarginsF>
 #include <QPainter>
 #include <QPointF>
+#include <QStringList>
 #include <QSvgGenerator>
 #include <QTransform>
 #include <Qt>
@@ -170,6 +171,8 @@ void BondItem::updateCachedData()
     }
 
     m_colors = getColors();
+
+    setToolTip(getTooltip());
 
     // TODO: calculate bond intersections, store clipping path
     // TODO: deal with atom radii for aromatics
@@ -627,6 +630,54 @@ std::vector<QColor> BondItem::getColors() const
         return {start_color, end_color};
     }
     return {start_color};
+}
+
+QString BondItem::getTooltip() const
+{
+    const QString STEREO_PREFIX = "Stereo: ";
+    const QString QUERY_PREFIX = "Query: ";
+    QStringList tooltip_parts;
+    RDKit::Bond::BondDir bond_direction = m_bond->getBondDir();
+
+    // Check for stereochemistry indicators on single bonds
+    if (m_bond->getBondType() == RDKit::Bond::BondType::SINGLE) {
+        if (bond_direction == RDKit::Bond::BondDir::UNKNOWN) {
+            tooltip_parts.append(STEREO_PREFIX + "unknown");
+        }
+    }
+
+    // Check for crossed double bond (E/Z unknown)
+    if (m_bond->getBondType() == RDKit::Bond::BondType::DOUBLE) {
+        if (bond_direction == RDKit::Bond::BondDir::EITHERDOUBLE) {
+            tooltip_parts.append(STEREO_PREFIX + "E/Z unknown");
+        }
+    }
+
+    // Add annotation text tooltip with descriptions for bond queries
+    if (!m_annotation_text.isEmpty()) {
+        // Determine if this is a stereo label or query
+        // Note: RDKit's addStereoAnnotations sets bondNote to "(E)" or "(Z)"
+        // with parentheses, so we check for those exact formats
+        if (m_annotation_text == "(E)" || m_annotation_text == "(Z)") {
+            tooltip_parts.append(STEREO_PREFIX + m_annotation_text);
+        } else if (m_annotation_text == "Any") {
+            tooltip_parts.append(QUERY_PREFIX + "Any bond type");
+        } else if (m_annotation_text == "S/D") {
+            tooltip_parts.append(QUERY_PREFIX + "Single or double bond");
+        } else if (m_annotation_text == "S/A") {
+            tooltip_parts.append(QUERY_PREFIX + "Single or aromatic bond");
+        } else if (m_annotation_text == "D/A") {
+            tooltip_parts.append(QUERY_PREFIX + "Double or aromatic bond");
+        } else if (m_annotation_text == "S/D/A") {
+            tooltip_parts.append(QUERY_PREFIX + "Single, double, or aromatic bond");
+        } else {
+            // For other labels, show as-is with appropriate prefix
+            // Most likely query-related
+            tooltip_parts.append(QUERY_PREFIX + m_annotation_text);
+        }
+    }
+
+    return tooltip_parts.join("\n");
 }
 
 void BondItem::paint(QPainter* painter, const QStyleOptionGraphicsItem* option,

--- a/src/schrodinger/sketcher/molviewer/bond_item.h
+++ b/src/schrodinger/sketcher/molviewer/bond_item.h
@@ -122,6 +122,15 @@ class SKETCHER_API BondItem : public AbstractBondOrConnectorItem
     std::vector<QColor> m_colors;
 
     /**
+     * Get tooltip text based on bond stereochemistry or query labels.
+     * Returns tooltip text for features related to stereochemistry or query features.
+     * If a bond has both stereochemistry and query features, both are shown on
+     * separate lines (e.g., "Stereo: (E)\nQuery: Any bond type").
+     * @return tooltip text, or empty string if no tooltip should be shown
+     */
+    QString getTooltip() const;
+
+    /**
      * @return a list of the colors to be used for painting this bond. If the
      * user has selected a color for this bond, then the list will contain only
      * that. If the user has not selected a color for the bond, but has selected

--- a/test/schrodinger/sketcher/molviewer/test_atom_item.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_atom_item.cpp
@@ -36,6 +36,7 @@ class TestAtomItem : public AtomItem
     using AtomItem::findHsDirection;
     using AtomItem::getQueryLabel;
     using AtomItem::getSubrects;
+    using AtomItem::getTooltip;
     using AtomItem::m_bounding_rect;
     using AtomItem::m_charge_and_radical_label_rect;
     using AtomItem::m_charge_and_radical_label_text;
@@ -445,6 +446,140 @@ BOOST_AUTO_TEST_CASE(test_chirality_label_positioning)
         BOOST_TEST(QLineF(centroid, chirality_label_center).length() <
                    QLineF(centroid, item->pos()).length());
     }
+}
+
+BOOST_AUTO_TEST_CASE(test_chirality_label_tooltip)
+{
+    // Test that atoms with chirality labels have tooltips
+    auto [atom_items, scene] = createAtomItems("CC[C@H](C)N");
+
+    // Find the chiral center (should be at index 2)
+    std::shared_ptr<TestAtomItem> chiral_atom;
+    for (auto item : atom_items) {
+        if (!item->m_chirality_label_text.isEmpty()) {
+            chiral_atom = item;
+            break;
+        }
+    }
+
+    BOOST_TEST_REQUIRE(chiral_atom != nullptr);
+    BOOST_TEST(chiral_atom->m_chirality_label_text == "(S)");
+    BOOST_TEST(chiral_atom->m_chirality_label_rect.isValid());
+
+    // Tooltip should show the chirality label with Stereo prefix
+    BOOST_TEST(chiral_atom->toolTip() == "Stereo: (S)");
+}
+
+BOOST_AUTO_TEST_CASE(test_wildcard_atom_tooltips)
+{
+    // Test that wildcard atoms have descriptive tooltips
+    struct TestCase {
+        AtomQuery wildcard;
+        QString expected_tooltip;
+    };
+
+    std::vector<TestCase> test_cases = {
+        {AtomQuery::Q, "Query: Any heteroatom"},
+        {AtomQuery::A, "Query: Any heavy atom"},
+        {AtomQuery::X, "Query: Any halogen"},
+        {AtomQuery::M, "Query: Any metal"},
+        {AtomQuery::QH, "Query: Any heteroatom or hydrogen"},
+        {AtomQuery::AH, "Query: Any heavy atom or hydrogen"},
+        {AtomQuery::XH, "Query: Any halogen or hydrogen"},
+        {AtomQuery::MH, "Query: Any metal or hydrogen"}
+    };
+
+    for (const auto& [wildcard, expected_tooltip] : test_cases) {
+        auto props = std::make_shared<AtomQueryProperties>();
+        props->query_type = QueryType::WILDCARD;
+        props->wildcard = wildcard;
+
+        auto [atom_item, test_scene] = createAtomItem(props);
+
+        // Wildcards should have descriptive tooltips
+        BOOST_TEST(atom_item->toolTip().toStdString() == expected_tooltip.toStdString());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_query_atom_with_constraints_tooltip)
+{
+    // Test that query atoms with additional constraints show the constraint text
+    auto props = std::make_shared<AtomQueryProperties>();
+    props->query_type = QueryType::WILDCARD;
+    props->wildcard = AtomQuery::X;
+    props->ring_count_type = QueryCount::EXACTLY;
+    props->ring_count_exact_val = 2;
+    props->num_connections = 2;
+
+    auto [atom_item, test_scene] = createAtomItem(props);
+
+    BOOST_TEST(atom_item->m_main_label_text == "X");
+    BOOST_TEST(atom_item->m_query_label_text == "X2&R2");
+
+    // Should show the query constraint text with Query prefix
+    BOOST_TEST(atom_item->toolTip() == "Query: X2&R2");
+}
+
+BOOST_AUTO_TEST_CASE(test_atom_list_tooltip)
+{
+    // Test that atom lists show the list as tooltip
+    auto props = std::make_shared<AtomQueryProperties>();
+    props->query_type = QueryType::ALLOWED_LIST;
+    props->allowed_list = {Element::C, Element::N};
+
+    auto [atom_item, test_scene] = createAtomItem(props);
+
+    BOOST_TEST(atom_item->m_main_label_text == "*");
+    BOOST_TEST(atom_item->m_query_label_text == "[C,N]");
+
+    // Should show the atom list with Query prefix
+    BOOST_TEST(atom_item->toolTip() == "Query: [C,N]");
+}
+
+BOOST_AUTO_TEST_CASE(test_no_tooltip_for_normal_atoms)
+{
+    // Test that normal atom labels don't have tooltips
+    std::vector<std::string> normal_atoms = {"C", "N", "O", "S", "P"};
+
+    for (const auto& smiles : normal_atoms) {
+        auto [atom_item, scene] = createAtomItem(smiles);
+
+        // Normal atoms should not have tooltips
+        BOOST_TEST(atom_item->toolTip().isEmpty());
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_chirality_takes_precedence_over_query)
+{
+    // Test that atoms with only chirality (no query) show only stereo tooltip
+    auto [atom_items, scene] = createAtomItems("C[C@H](N)S");
+
+    for (auto item : atom_items) {
+        if (!item->m_chirality_label_text.isEmpty()) {
+            // Should show chirality with Stereo prefix
+            BOOST_TEST(item->toolTip() == "Stereo: " + item->m_chirality_label_text);
+        }
+    }
+}
+
+BOOST_AUTO_TEST_CASE(test_atom_with_both_chirality_and_query)
+{
+    // Test that atoms with both chirality and query features show both in tooltip
+    auto props = std::make_shared<AtomQueryProperties>();
+    props->query_type = QueryType::SPECIFIC_ELEMENT;
+    props->element = Element::C;
+    props->num_connections = 2;
+
+    auto [atom_item, test_scene] = createAtomItem(props);
+
+    // Manually set chirality label to simulate a chiral query atom
+    atom_item->m_chirality_label_text = "(R)";
+    atom_item->m_query_label_text = "X2";
+
+    // Tooltip should show both stereo and query on separate lines
+    QString tooltip = atom_item->getTooltip();
+    BOOST_TEST(tooltip.contains("Stereo: (R)"));
+    BOOST_TEST(tooltip.contains("Query: X2"));
 }
 
 } // namespace sketcher

--- a/test/schrodinger/sketcher/molviewer/test_bond_item.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_bond_item.cpp
@@ -24,8 +24,9 @@
 #include "schrodinger/sketcher/rdkit/atoms_and_bonds.h"
 
 BOOST_GLOBAL_FIXTURE(QApplicationRequiredFixture);
-// Boost doesn't know how to print QPoints
+// Boost doesn't know how to print QPoints or QStrings
 BOOST_TEST_DONT_PRINT_LOG_VALUE(QPointF);
+BOOST_TEST_DONT_PRINT_LOG_VALUE(QString);
 
 using schrodinger::rdkit_extensions::Format;
 
@@ -318,6 +319,35 @@ BOOST_AUTO_TEST_CASE(test_dashed_bond_zero_length)
     auto [num_dashes, wedge_start, offset_towards_p2, offset_towards_p3,
           dashes] = bond_item->calcDashedWedgeParams(QLineF(0, 0, 0, 0));
     BOOST_TEST(num_dashes == 1);
+}
+
+BOOST_AUTO_TEST_CASE(test_bond_stereo_tooltips)
+{
+    // Test that E/Z double bonds have correct tooltips
+    // The annotation text comes with parentheses like "(E)" or "(Z)"
+    // and the tooltip should preserve them for consistency with atom stereo labels
+    auto [bond_items, scene] = createStructure("C/C(N)=C(/C)O");
+
+    // Find the double bond with E stereochemistry
+    bool found_stereo_bond = false;
+    for (auto bond_item : bond_items) {
+        if (bond_item->m_annotation_text == "(E)") {
+            BOOST_TEST(bond_item->toolTip() == "Stereo: (E)");
+            found_stereo_bond = true;
+        }
+    }
+    BOOST_TEST(found_stereo_bond);
+
+    // Test Z stereochemistry
+    auto [bond_items_z, scene_z] = createStructure("C\\C=C/C");
+    found_stereo_bond = false;
+    for (auto bond_item : bond_items_z) {
+        if (bond_item->m_annotation_text == "(Z)") {
+            BOOST_TEST(bond_item->toolTip() == "Stereo: (Z)");
+            found_stereo_bond = true;
+        }
+    }
+    BOOST_TEST(found_stereo_bond);
 }
 
 } // namespace sketcher


### PR DESCRIPTION
* Linked Case: https://schrodinger.atlassian.net/browse/SKETCH-2533

### Description

This PR adds descriptive tooltips to atom and bond items in the sketcher to help users understand stereochemistry labels and query features. Tooltips only appear for non-obvious features to avoid clutter.

**Atom Tooltips:**
- Chirality labels: "Stereo: (R)", "Stereo: (S)", etc.
- Query wildcards with descriptions: "Query: Any heteroatom", "Query: Any halogen", etc.
- Query constraints: "Query: X2&R2" (connections and ring count)
- Atom lists: "Query: [C,N]"
- Multi-line support for atoms with both stereochemistry and query features

**Bond Tooltips:**
- E/Z stereochemistry: "Stereo: (E)", "Stereo: (Z)"
- Unknown stereochemistry: "Stereo: unknown" (wavy bonds)
- Unknown E/Z: "Stereo: E/Z unknown" (crossed double bonds)
- Bond queries: "Query: Any bond type", "Query: Single or double bond", etc.
- Multi-line support for bonds with both stereochemistry and query features

**Implementation Details:**
- Added `AtomItem::getTooltip()` method that returns tooltip text based on chirality and query labels
- Added `BondItem::getTooltip()` method that returns tooltip text based on stereochemistry and query annotations
- Tooltips are set in `updateCachedData()` for static display (not dynamic hover-based)
- Used `QStringList` to accumulate tooltip parts and join with newlines for multi-feature support
- Normal atoms and bonds have no tooltips to avoid clutter

### Testing Done

- Added comprehensive test coverage:
  - `test_chirality_label_tooltip`: Verifies chirality tooltips on atoms
  - `test_wildcard_atom_tooltips`: Tests all 8 wildcard types (A, Q, X, M, AH, QH, XH, MH) with descriptive text
  - `test_query_atom_with_constraints_tooltip`: Tests constraint display (X2&R2)
  - `test_atom_list_tooltip`: Tests atom list display
  - `test_no_tooltip_for_normal_atoms`: Ensures normal atoms have no tooltips
  - `test_atom_with_both_chirality_and_query`: Tests multi-line tooltips for atoms with both features
  - `test_bond_stereo_tooltips`: Tests E/Z stereochemistry tooltips on bonds
- All existing tests pass
- Manually tested in the sketcher UI with various molecules containing stereochemistry and query features