### PR TITLE
SKETCH-2487: Fix allowed list labels showing atomic numbers instead of element symbols

### DIFF
--- a/src/schrodinger/sketcher/rdkit/atom_properties.cpp
+++ b/src/schrodinger/sketcher/rdkit/atom_properties.cpp
@@ -311,11 +311,17 @@ std::ostream& operator<<(std::ostream& os, const AbstractAtomProperties& props)
 
 bool AtomQueryProperties::hasPropertiesBeyondQueryType() const
 {
+    // General properties excluding enhanced_stereo (stereo doesn't affect
+    // whether we can display allowed lists with element symbols - SKETCH-2487)
+    const AtomQueryPropertyList general_props_excl_stereo = {
+        &AtomQueryProperties::isotope,
+        &AtomQueryProperties::charge,
+        &AtomQueryProperties::unpaired_electrons,
+    };
     auto default_props = AtomQueryProperties();
     return !compare_query_properties(
         this, &default_props,
-        concat_query_props(
-            {GENERAL_QUERY_PROPERTIES, ADVANCED_QUERY_PROPERTIES}));
+        concat_query_props({general_props_excl_stereo, ADVANCED_QUERY_PROPERTIES}));
 }
 
 bool AtomQueryProperties::hasAdvancedProperties() const

--- a/src/schrodinger/sketcher/rdkit/atom_properties.h
+++ b/src/schrodinger/sketcher/rdkit/atom_properties.h
@@ -124,7 +124,9 @@ struct SKETCHER_API AtomQueryProperties : AbstractAtomProperties {
 
     /**
      * Does this query have any properties other than those that directly relate
-     * to the query type (e.g. allowed_list)?
+     * to the query type (e.g. allowed_list)? Note: stereo properties are
+     * excluded from this check since they don't prevent displaying allowed
+     * lists with element symbols (SKETCH-2487).
      */
     bool hasPropertiesBeyondQueryType() const;
 

--- a/test/schrodinger/sketcher/molviewer/test_atom_item.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_atom_item.cpp
@@ -398,6 +398,18 @@ BOOST_AUTO_TEST_CASE(test_queries_rendering)
         BOOST_TEST(atom_item->m_query_label_text == "\"[#6,#7;+]\"");
     }
 
+    { // atom list with enhanced stereo (SKETCH-2487)
+        // Stereo properties shouldn't prevent displaying element symbols
+        auto props = std::make_shared<AtomQueryProperties>();
+        props->query_type = QueryType::ALLOWED_LIST;
+        props->allowed_list = {Element::N, Element::C, Element::O, Element::F};
+        props->enhanced_stereo = EnhancedStereo(RDKit::StereoGroupType::STEREO_ABSOLUTE, 0);
+        auto [atom_item, test_scene] = createAtomItem(props);
+        BOOST_TEST(atom_item->m_main_label_text == "*");
+        // Should use element symbols, not atomic numbers
+        BOOST_TEST(atom_item->m_query_label_text == "[N,C,O,F]");
+    }
+
     { // wildcard query with advanced properties
         auto props = std::make_shared<AtomQueryProperties>();
         props->query_type = QueryType::WILDCARD;

--- a/test/schrodinger/sketcher/rdkit/test_atom_properties.cpp
+++ b/test/schrodinger/sketcher/rdkit/test_atom_properties.cpp
@@ -18,6 +18,7 @@ BOOST_TEST_DONT_PRINT_LOG_VALUE(schrodinger::sketcher::EnhancedStereo)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(
     std::optional<schrodinger::sketcher::EnhancedStereo>)
 BOOST_TEST_DONT_PRINT_LOG_VALUE(std::nullopt_t)
+BOOST_TEST_DONT_PRINT_LOG_VALUE(schrodinger::sketcher::QueryType)
 
 namespace schrodinger
 {
@@ -331,6 +332,7 @@ BOOST_DATA_TEST_CASE(test_atom_properties_round_trip_smarts,
 /**
  * Ensure that hasAdvancedProperties() and hasPropertiesBeyondQueryType() return
  * true when the appropriate properties are set to non-default values.
+ * Note: hasPropertiesBeyondQueryType excludes stereo properties (SKETCH-2487).
  */
 BOOST_AUTO_TEST_CASE(test_hasAdvancedProperties)
 {
@@ -341,6 +343,13 @@ BOOST_AUTO_TEST_CASE(test_hasAdvancedProperties)
     query_props.element = Element::O;
     BOOST_TEST(!query_props.hasPropertiesBeyondQueryType());
     BOOST_TEST(!query_props.hasAdvancedProperties());
+
+    // Setting stereo should NOT trigger hasPropertiesBeyondQueryType (SKETCH-2487)
+    query_props.enhanced_stereo = EnhancedStereo(RDKit::StereoGroupType::STEREO_ABSOLUTE, 0);
+    BOOST_TEST(!query_props.hasPropertiesBeyondQueryType());
+    BOOST_TEST(!query_props.hasAdvancedProperties());
+    query_props.enhanced_stereo = std::nullopt;
+
     query_props.charge = 2;
     BOOST_TEST(query_props.hasPropertiesBeyondQueryType());
     BOOST_TEST(!query_props.hasAdvancedProperties());


### PR DESCRIPTION
* Linked Case: https://schrodinger.atlassian.net/browse/SKETCH-2487

### Description

This PR fixes a bug where atom labels with allowed lists would unexpectedly display using atomic numbers like [#7,#6,#8,#9] instead of element symbols like [N,C,O,F] when the atom had chiral center properties.

The root cause was in the getQueryLabel() function, which calls hasPropertiesBeyondQueryType() to determine whether to display a simplified label with element symbols or fall back to SMARTS notation. The method was including enhanced_stereo properties in its check, so atoms with chiral centers would always trigger the fallback to SMARTS notation with atomic numbers.

The fix modifies hasPropertiesBeyondQueryType() to exclude stereo properties from the check. Since stereo properties don't conflict with displaying allowed lists using element symbols, there's no need to fall back to SMARTS notation for atoms that only have stereo properties set.

This is a minimal change that affects only the hasPropertiesBeyondQueryType() implementation and its documentation. The method now creates a local property list excluding enhanced_stereo instead of using the global GENERAL_QUERY_PROPERTIES list which included it.

### Testing Done

All existing tests pass. Added a new regression test in test_atom_item.cpp that validates allowed lists with stereo properties display as [N,C,O,F] rather than [#7,#6,#8,#9]. Also added a unit test in test_atom_properties.cpp to verify that setting enhanced_stereo doesn't trigger hasPropertiesBeyondQueryType().

Verified that the existing behavior for atoms with other properties (like charge) is preserved. For example, an allowed list with a charge still correctly displays as "[#6,#7;+]" in SMARTS notation.

Built and ran the full test suite with buildinger sketcher --with-tests.
