### PR TITLE
SKETCH-1889: Add environment variable for debug mode atom indices

### DIFF
--- a/src/schrodinger/sketcher/model/sketcher_model.cpp
+++ b/src/schrodinger/sketcher/model/sketcher_model.cpp
@@ -75,6 +75,7 @@ SketcherModel::SketcherModel(QObject* parent) : QObject(parent)
 {
     // Initialize model to default state
     reset();
+    setFontSize(m_font_size); // to apply debug mode scaling if needed
     connect(this, &SketcherModel::selectionChanged, this,
             &SketcherModel::onSelectionChanged);
     connect(this, &SketcherModel::interactiveItemsChanged, this,
@@ -560,6 +561,11 @@ bool SketcherModel::hasDarkColorScheme() const
 
 void SketcherModel::setFontSize(int size)
 {
+    // Apply debug mode scaling if atom indices are shown
+    constexpr double DEBUG_MODE_FONT_SCALING = 0.7;
+    if (m_atom_display_settings.m_show_atom_indices) {
+        size = static_cast<int>(size * DEBUG_MODE_FONT_SCALING);
+    }
     m_font_size = size;
     emit displaySettingsChanged();
 }

--- a/src/schrodinger/sketcher/molviewer/atom_display_settings.cpp
+++ b/src/schrodinger/sketcher/molviewer/atom_display_settings.cpp
@@ -1,5 +1,7 @@
 #include "schrodinger/sketcher/molviewer/atom_display_settings.h"
 
+#include <cstdlib>
+
 #include "schrodinger/sketcher/model/sketcher_model.h"
 
 namespace schrodinger
@@ -10,6 +12,13 @@ namespace sketcher
 AtomDisplaySettings::AtomDisplaySettings()
 {
     setColorScheme(ColorScheme::DEFAULT);
+
+    // Check if debug mode should be enabled via environment variable
+    const char* debug_mode_env = std::getenv("SCHRODINGER_SKETCHER_DEBUG_MODE");
+    if (debug_mode_env != nullptr && debug_mode_env[0] != '\0') {
+        // Any non-empty value enables the feature
+        m_show_atom_indices = true;
+    }
 }
 
 void AtomDisplaySettings::setColorScheme(const ColorScheme& scheme,

--- a/src/schrodinger/sketcher/molviewer/atom_display_settings.h
+++ b/src/schrodinger/sketcher/molviewer/atom_display_settings.h
@@ -88,6 +88,11 @@ class SKETCHER_API AtomDisplaySettings
     bool m_show_symbol_for_H_isotopes = false;
 
     /**
+     * Whether to display RDKit mol atom indices as labels (developer option)
+     */
+    bool m_show_atom_indices = false;
+
+    /**
      * The width of the pen used to draw attachment point squiggles.
      */
     qreal m_squiggle_pen_width = BOND_DEFAULT_PEN_WIDTH;

--- a/src/schrodinger/sketcher/molviewer/atom_item.cpp
+++ b/src/schrodinger/sketcher/molviewer/atom_item.cpp
@@ -389,6 +389,11 @@ AtomItem::determineLabelType() const
         label_is_visible = true;
     }
 
+    // Append atom index to the main label when debug mode is enabled
+    if (m_settings.m_show_atom_indices && label_is_visible) {
+        main_label_text += ":" + std::to_string(m_atom->getIdx());
+    }
+
     return {QString::fromStdString(main_label_text),
             squiggle_path,
             label_is_visible,
@@ -627,6 +632,9 @@ bool AtomItem::determineLabelIsVisible() const
     // note that this method does not take m_valence_error_is_visible into
     // account.  If that value is true (and up-to-date), then the label should
     // be visible.
+    if (m_settings.m_show_atom_indices) {
+        return true;
+    }
     if (m_settings.m_carbon_labels == CarbonLabels::ALL) {
         return true;
     }

--- a/src/schrodinger/sketcher/tool/draw_fragment_scene_tool.cpp
+++ b/src/schrodinger/sketcher/tool/draw_fragment_scene_tool.cpp
@@ -127,6 +127,8 @@ void AbstractHintFragmentItem::updateSettings()
 {
     m_atom_display_settings.setMonochromeColorScheme(STRUCTURE_HINT_COLOR);
     m_bond_display_settings.setMonochromeColorScheme(STRUCTURE_HINT_COLOR);
+    // Disable atom indices for hints/previews
+    m_atom_display_settings.m_show_atom_indices = false;
 }
 
 void AbstractHintFragmentItem::createGraphicsItems()

--- a/test/schrodinger/sketcher/molviewer/test_atom_item.cpp
+++ b/test/schrodinger/sketcher/molviewer/test_atom_item.cpp
@@ -460,5 +460,37 @@ BOOST_AUTO_TEST_CASE(test_chirality_label_positioning)
     }
 }
 
+BOOST_AUTO_TEST_CASE(test_atom_index_display)
+{
+    auto [atom_items, test_scene] = createAtomItems("CCN");
+
+    // By default, atom indices should not be shown (carbons are unlabeled)
+    BOOST_TEST(!atom_items[0]->m_label_is_visible); // C
+    BOOST_TEST(!atom_items[1]->m_label_is_visible); // C
+    BOOST_TEST(atom_items[2]->m_label_is_visible);  // N
+    BOOST_TEST(atom_items[2]->m_main_label_text == "N");
+
+    // Enable atom index display
+    auto display_settings(
+        *test_scene->m_sketcher_model->getAtomDisplaySettingsPtr());
+    display_settings.m_show_atom_indices = true;
+    test_scene->m_sketcher_model->setAtomDisplaySettings(display_settings);
+
+    // Update all atom items
+    for (auto atom_item : atom_items) {
+        atom_item->updateCachedData();
+    }
+
+    // Verify that all atoms now show labels with indices appended
+    BOOST_TEST(atom_items[0]->m_label_is_visible);
+    BOOST_TEST(atom_items[0]->m_main_label_text == "C:0");
+
+    BOOST_TEST(atom_items[1]->m_label_is_visible);
+    BOOST_TEST(atom_items[1]->m_main_label_text == "C:1");
+
+    BOOST_TEST(atom_items[2]->m_label_is_visible);
+    BOOST_TEST(atom_items[2]->m_main_label_text == "N:2");
+}
+
 } // namespace sketcher
 } // namespace schrodinger


### PR DESCRIPTION
* Linked Case: SKETCH-1889

### Description
This PR converts the atom indices display feature from a UI checkbox to environment variable configuration. The feature is now enabled by setting the `SCHRODINGER_SKETCHER_DEBUG_MODE` environment variable to any non-empty value. This approach enables developers to debug atom indexing issues without requiring UI interaction, which is particularly useful for automated testing and debugging scenarios.

The implementation follows a clean architecture with minimal pass-through layers. The environment variable is checked directly in the `AtomDisplaySettings` constructor, which sets the `m_show_atom_indices` flag. When enabled, atom indices are appended to element labels in the format "Element:Index" (e.g., "C:0", "N:2").

Font scaling for debug mode has been centralized into the `SketcherModel::setFontSize()` method, which automatically applies a 0.7x scaling factor when atom indices are shown. This makes the scaling transparent to all callers - they simply call `setFontSize()` with their desired size, and the method handles the debug mode scaling internally. The `SketcherModel` constructor calls `setFontSize(m_font_size)` during initialization to ensure proper scaling is applied at startup.

The `AtomItem` class has been updated to force labels visible and append indices when debug mode is enabled. Additionally, the `DrawFragmentSceneTool` explicitly disables atom indices for preview hints to avoid visual clutter during drawing operations.

Importantly, this implementation adds no new public API to `SketcherWidget`, maintaining a clean interface and keeping the debug functionality properly encapsulated within the model layer.

### Testing Done
The changes build successfully with `buildinger sketcher`. A comprehensive unit test has been added to `test_atom_item.cpp` that verifies both default behavior (indices not shown) and enabled behavior (all atoms show labels with indices appended). The test validates label visibility and format for multiple atom types. Manual testing with the environment variable set confirms proper font scaling and index display throughout the application.
