### PR TITLE
SKETCH-2662: Add boolean parameter to sketcher_allow_monomeric and format support to sketcher_import_text

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -24,6 +24,7 @@ using schrodinger::rdkit_extensions::Format;
 using schrodinger::sketcher::ImageFormat;
 using schrodinger::sketcher::SketcherWidget;
 
+#ifdef __EMSCRIPTEN__
 // For the WebAssembly build, we need to be able to get the sketcher
 // instance we are running from a function/static method. We'll use a
 // singleton for that.
@@ -33,10 +34,14 @@ SketcherWidget& get_sketcher_instance()
     return instance;
 }
 
-void sketcher_import_text(const std::string& text)
+void sketcher_import_text(
+    const std::string& text,
+    emscripten::val format_val = emscripten::val::undefined())
 {
     auto& sk = get_sketcher_instance();
-    sk.addFromString(text);
+    auto format = format_val.isUndefined() ? Format::AUTO_DETECT
+                                           : format_val.as<Format>();
+    sk.addFromString(text, format);
 }
 
 std::string sketcher_export_text(Format format)
@@ -70,16 +75,17 @@ bool sketcher_has_monomers()
     return schrodinger::rdkit_extensions::isMonomeric(*mol);
 }
 
-void sketcher_allow_monomeric()
+void sketcher_allow_monomeric(bool allow_monomeric)
 {
     auto& sk = get_sketcher_instance();
     return sk.setInterfaceType(
-        schrodinger::sketcher::InterfaceType::ATOMISTIC_OR_MONOMERIC);
+        allow_monomeric
+            ? schrodinger::sketcher::InterfaceType::ATOMISTIC_OR_MONOMERIC
+            : schrodinger::sketcher::InterfaceType::ATOMISTIC);
 }
 
 void sketcher_changed()
 {
-#ifdef __EMSCRIPTEN__
     EM_ASM({
         if (Module.sketcher_changed_callback) {
             setTimeout(
@@ -91,10 +97,8 @@ void sketcher_changed()
                 100);
         }
     });
-#endif
 }
 
-#ifdef __EMSCRIPTEN__
 EMSCRIPTEN_BINDINGS(sketcher)
 {
     emscripten::enum_<Format>("Format")
@@ -133,7 +137,6 @@ EMSCRIPTEN_BINDINGS(sketcher)
     emscripten::function("sketcher_allow_monomeric", &sketcher_allow_monomeric);
     // see sketcher_changed_callback above
 }
-#endif
 
 void apply_stylesheet(QApplication& app)
 {
@@ -145,6 +148,7 @@ void apply_stylesheet(QApplication& app)
     QString style(styleFile.readAll());
     app.setStyleSheet(style);
 }
+#endif
 
 int main(int argc, char** argv)
 {

--- a/test/wasm/wasm_api.test.js
+++ b/test/wasm/wasm_api.test.js
@@ -55,7 +55,7 @@ test.describe('WASM Sketcher API', () => {
       if (!importUnsupported) {
         const importSuccessful = await page.evaluate((exportedText) => {
           Module.sketcher_clear();
-          Module.sketcher_allow_monomeric();
+          Module.sketcher_allow_monomeric(true);
           Module.sketcher_import_text(exportedText);
           return !Module.sketcher_is_empty();
         }, exportedText);
@@ -93,7 +93,7 @@ test.describe('WASM Sketcher API', () => {
 
     const hasMonomersAfterHelmImport = await page.evaluate(() => {
       Module.sketcher_clear();
-      Module.sketcher_allow_monomeric();
+      Module.sketcher_allow_monomeric(true);
       Module.sketcher_import_text('PEPTIDE1{A.S.D.F.G.H.W}$$$$V2.0');
       return Module.sketcher_has_monomers();
     });


### PR DESCRIPTION
* Linked Case: SKETCH-2662

### Description

This PR enhances the WebAssembly API by adding more granular control over the sketcher's interface capabilities and import functionality. The sketcher_allow_monomeric function now accepts a boolean parameter that determines whether to enable both atomistic and monomeric modes (when true) or only atomistic mode (when false). Previously, calling this function always enabled the combined ATOMISTIC_OR_MONOMERIC mode, which didn't provide a way to switch back to atomistic-only mode programmatically.

Additionally, the sketcher_import_text function now accepts an optional format parameter, allowing callers to explicitly specify the input format rather than relying solely on auto-detection. The format parameter defaults to AUTO_DETECT to maintain backward compatibility with existing code. The WebAssembly-specific code sections have been reorganized with cleaner #ifdef __EMSCRIPTEN__ guards to improve code organization.

### Testing Done

Updated all existing wasm_api.test.js test cases to use the new function signature by passing the boolean argument to sketcher_allow_monomeric. All tests continue to pass with the new implementation, confirming backward compatibility when passing true. The changes maintain the existing behavior for current users while enabling new use cases that require switching between interface modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)